### PR TITLE
replacement of signal slot by listeners to file event + misc. cleaning and refacto

### DIFF
--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -201,15 +201,15 @@ class ClearCachePostProc
         }
 
         if (MathUtility::canBeInterpretedAsInteger($entry)) {
-             $languages = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($pageId)->getAllLanguages();
-    
+            $languages = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($pageId)->getAllLanguages();
+
             if (count($languages) > 0) {
-               $this->enqueue($this->buildLink($entry, array('_language' => 0)) . $wildcard, $distributionIds);
+                $this->enqueue($this->buildLink($entry, array('_language' => 0)) . $wildcard, $distributionIds);
                 foreach ($languages as $k => $lang) {
-                   if($lang->getLanguageId() != 0) {
-                       $this->enqueue($this->buildLink($entry, array('_language' => $lang->getLanguageId())) . $wildcard, $distributionIds);                                                            
-                   }                                                                   
-               }
+                    if($lang->getLanguageId() != 0) {
+                        $this->enqueue($this->buildLink($entry, array('_language' => $lang->getLanguageId())) . $wildcard, $distributionIds);
+                    }
+                }
             } else {
                 $this->enqueue($this->buildLink($entry) . $wildcard, $distributionIds);
             }

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -79,24 +79,10 @@ class ClearCachePostProc
     public function __construct()
     {
         /* Retrieve extension configuration */
-        $this->cloudFrontConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('tm_cloudfront')['cloudfront'];
-        $this->init();
+        $this->cloudFrontConfiguration =
+            GeneralUtility::makeInstance(ExtensionConfiguration::class)
+                ->get('tm_cloudfront')['cloudfront'];
     }
-
-    /**
-     * @return void
-     */
-    public function getCfDistributionIds()
-    {
-        $this->init();
-    }
-
-    /**
-     * Initialize tsfe for speaking url link creation
-     * @return void
-     */
-    protected function init()
-    {/* init tsfe */}
 
     /**
      * Clear cache post processor.

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -220,6 +220,7 @@ class ClearCachePostProc
 
     protected function enqueue($link, $distributionIds)
     {
+        $link = str_replace('//', '/', $link);
         $distArray = explode(',', $distributionIds);
         // for index.php link style
         if (substr($link, 0, 1) != '/') {

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -142,7 +142,7 @@ class ClearCachePostProc
                 $this->queueClearCache($uid_page, false, $distributionIds);
             } else {
 
-                if (!$tsConfig['cearCache_disable']) {
+                if (!$tsConfig['clearCache_disable']) {
 
                     if (is_numeric($parentId)) {
                         $parentId = intval($parentId);

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -188,7 +188,7 @@ class ClearCachePostProc
     {
         $wildcard = '';
         if ($recursive) {
-            $wildcard = '*';
+            $wildcard = '/*';
         }
         if ($pageId == 0) {
             $entry = '/';

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -292,7 +292,7 @@ class ClearCachePostProc
 
             if (((!empty($this->cloudFrontConfiguration['mode'])) && ($this->cloudFrontConfiguration['mode'] == 'live')) || ($force)) {
                 $cloudFront = GeneralUtility::makeInstance('Aws\CloudFront\CloudFrontClient', $options);
-                $GLOBALS['BE_USER']->writelog(4,0,0,0,implode(',', $paths). ' ('.$distId.')', "tm_cloudfront");
+                $GLOBALS['BE_USER']->writelog(4,0,0,0,$value['pathsegment']. ' ('.$distId.')', "tm_cloudfront");
                 try {
                     $result = $cloudFront->createInvalidation([
                         'DistributionId' => $distId, // REQUIRED

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -339,18 +339,21 @@ class ClearCachePostProc
     }
 
     /**
-     * @param $file_or_folder
+     * @param File | Folder $file_or_folder
      *
      * @return void
      * @throws \Doctrine\DBAL\Driver\Exception
      * @throws \Doctrine\DBAL\Exception
      */
-    public function fileMod($file_or_folder)
+    public function fileMod($resource)
     {
         if (!empty($this->cloudFrontConfiguration['fileStorage'])) {
             foreach ($this->cloudFrontConfiguration['fileStorage'] as $storage => $distributionIds) {
-                if ($file_or_folder->getStorage()->getUid() == $storage) {
-                    $this->enqueue('/' . $file_or_folder->getPublicUrl(), $distributionIds);
+                if ($resource->getStorage()->getUid() == $storage) {
+                    $wildcard = $resource instanceof \Causal\FileList\Domain\Model\Folder
+                        ? '/*'
+                        : '';
+                    $this->enqueue($resource->getIdentifier() . $wildcard, $distributionIds);
                     $this->clearCache();
                 }
             }

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -306,7 +306,7 @@ class ClearCachePostProc
 
             if (((!empty($this->cloudFrontConfiguration['mode'])) && ($this->cloudFrontConfiguration['mode'] == 'live')) || ($force)) {
                 $cloudFront = GeneralUtility::makeInstance('Aws\CloudFront\CloudFrontClient', $options);
-                $GLOBALS['BE_USER']->writelog(4,0,0,0,$value['pathsegment']. ' ('.$distId.')', "tm_cloudfront");
+                $GLOBALS['BE_USER']->writelog(4,0,0,0,implode(',', $paths). ' ('.$distId.')', "tm_cloudfront");
                 try {
                     $result = $cloudFront->createInvalidation([
                         'DistributionId' => $distId, // REQUIRED

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -18,6 +18,16 @@ namespace Toumoro\TmCloudfront\Hooks;
  *
  ***/
 
+use TYPO3\CMS\Core\Resource\Event\AfterFileContentsSetEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFileCreatedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFileDeletedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFileMovedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFileRenamedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFileReplacedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFolderDeletedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFolderMovedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFolderRenamedEvent;
+use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -360,25 +370,7 @@ class ClearCachePostProc
         }
     }
 
-    /**
-     * A file has been added.
-     *
-     * @param AfterFileAddedEvent $event
-     */
-    public function afterFileAdded(AfterFileAddedEvent $event): void
-    {
-        $this->fileMod($event->getFolder());
-    }
 
-    /**
-     * A file has been copied.
-     *
-     * @param AfterFileCopiedEvent $event
-     */
-    public function afterFileCopied(AfterFileCopiedEvent $event): void
-    {
-        $this->fileMod($event->getFolder());
-    }
 
     /**
      * A file has been moved.
@@ -387,7 +379,6 @@ class ClearCachePostProc
      */
     public function afterFileMoved(AfterFileMovedEvent $event): void
     {
-        $this->fileMod($event->getFolder());
         $this->fileMod($event->getOriginalFolder());
     }
 
@@ -429,7 +420,7 @@ class ClearCachePostProc
     public function afterFileDeleted(AfterFileDeletedEvent $event): void
     {
         try {
-            $this->fileMod($event->getFile()->getParentFolder());
+            $this->fileMod($event->getFile());
         } catch (\Exception $e) {
             // Exception may happen when a file is moved to /_recycler_/ but the user has no access to it
         }
@@ -445,26 +436,6 @@ class ClearCachePostProc
         $this->fileMod($event->getFile()->getParentFolder());
     }
 
-    /**
-     * A folder has been added.
-     *
-     * @param AfterFolderAddedEvent $event
-     */
-    public function afterFolderAdded(AfterFolderAddedEvent $event): void
-    {
-        $this->fileMod($event->getFolder()->getParentFolder());
-    }
-
-    /**
-     * A folder has been copied.
-     *
-     * @param AfterFolderCopiedEvent $event
-     */
-    public function afterFolderCopied(AfterFolderCopiedEvent $event): void
-    {
-        $this->fileMod($event->getFolder());
-        $this->fileMod($event->getTargetFolder()->getParentFolder());
-    }
 
     /**
      * A folder has been moved.

--- a/Classes/Task/ClearTask.php
+++ b/Classes/Task/ClearTask.php
@@ -133,7 +133,7 @@ class ClearTask extends AbstractTask
                 )
                 ->execute();
         } catch (\Exception $e) {
-            $GLOBALS['BE_USER']->writelog(4, 0, 0, 0,'exception for invalidation paths :' . implode(', ', $pathsegments) . ' (' . $distId . '). Now iterating one by one',"tm_cloudfront");
+            $GLOBALS['BE_USER']->writelog(4, 0, 0, 0,'exception for invalidation paths :' . implode(', ', $pathsegments) . ' (' . $distId . ').',"tm_cloudfront");
             if (count($chunk) > 1) {
                 $GLOBALS['BE_USER']->writelog(4, 0, 0, 0,'Now iterating one by one (' . $distId . ')',"tm_cloudfront");
                 foreach (array_chunk($chunk, 1) as $atomic_chunk) {

--- a/Classes/Task/ClearTask.php
+++ b/Classes/Task/ClearTask.php
@@ -35,9 +35,7 @@ class ClearTask extends AbstractTask {
      */
     public function execute() {
         $this->cloudFrontConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('tm_cloudfront')['cloudfront'];
-        $distributionIds = $this->cloudFrontConfiguration['distributionIds'];
-        $distributionIds = explode(',',$distributionIds);
-        
+        $distributionIds = $this->getDistributionIds();
         foreach ($distributionIds as $key => $distId) {
             //clean duplicate values
             GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable("tx_tmcloudfront_domain_model_invalidation")
@@ -135,4 +133,26 @@ class ClearTask extends AbstractTask {
         }
         return $randomString;
     }
+
+    protected function getDistributionIds()
+    {
+        $pagesDistributionIds =
+            $this->cloudFrontConfiguration['distributionIds'] ?? [];
+        $distributionIds =
+            is_array($pagesDistributionIds)
+                ? $pagesDistributionIds
+                : explode(',', $pagesDistributionIds);
+        foreach ($this->cloudFrontConfiguration['fileStorage'] ?? [] as $fileStorageDistributionId) {
+            $distributionIds =
+                array_merge(
+                    $distributionIds,
+                    is_array($fileStorageDistributionId)
+                        ? $fileStorageDistributionId
+                        : explode(',', $fileStorageDistributionId)
+                );
+        }
+        return $distributionIds;
+
+    }
+
 }

--- a/Classes/Task/ClearTask.php
+++ b/Classes/Task/ClearTask.php
@@ -24,7 +24,8 @@ use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotCon
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 
 
-class ClearTask extends AbstractTask {
+class ClearTask extends AbstractTask
+{
 
     /**
      * @return bool
@@ -33,7 +34,8 @@ class ClearTask extends AbstractTask {
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      */
-    public function execute() {
+    public function execute()
+    {
         $this->cloudFrontConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('tm_cloudfront')['cloudfront'];
         $distributionIds = $this->getDistributionIds();
         foreach ($distributionIds as $key => $distId) {
@@ -51,7 +53,7 @@ class ClearTask extends AbstractTask {
                 )
                 ->execute()
                 ->fetchOne();
-    
+
             if ($count > 0) {
                 $options = [
                     'version' => $this->cloudFrontConfiguration['version'],
@@ -62,12 +64,12 @@ class ClearTask extends AbstractTask {
                     ]
                 ];
                 $cloudFront = GeneralUtility::makeInstance('Aws\CloudFront\CloudFrontClient', $options);
-    
+
                 $list = $cloudFront->listInvalidations([
                     'DistributionId' => $distId,
                     'MaxItems' => '30',
                 ]);
-    
+
                 /* the max is 15 but we let 5 spot available for manual clear cache in the backend */
                 $availableInvalidations = 10;
                 $items = $list->get('InvalidationList')['Items'];
@@ -78,7 +80,7 @@ class ClearTask extends AbstractTask {
                         }
                     }
                 }
-      
+
                 if ($availableInvalidations > 0) {
                     $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_tmcloudfront_domain_model_invalidation');
                     $rows = $queryBuilder
@@ -124,7 +126,8 @@ class ClearTask extends AbstractTask {
      * @param int $length length of the string
      * @return string
      */
-    protected function generateRandomString($length = 10) {
+    protected function generateRandomString($length = 10)
+    {
         $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $charactersLength = strlen($characters);
         $randomString = '';

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,3 +6,58 @@ services:
 
   Toumoro\TmCloudfront\:
     resource: '../Classes/*'
+
+  Toumoro\TmCloudfront\Hooks\ClearCachePostProc:
+    tags:
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFileAdded'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileAddedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFileCopied'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileCopiedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFileMoved'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileMovedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFileRenamed'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileRenamedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFileReplaced'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileReplacedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFileCreated'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileCreatedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFileDeleted'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileDeletedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFileContentsSet'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileContentsSetEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFolderAdded'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFolderAddedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFolderCopied'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFolderCopiedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFolderMoved'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFolderMovedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFolderRenamed'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFolderRenamedEvent
+      - name: event.listener
+        identifier: 'tm/file_list'
+        method: 'afterFolderDeleted'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFolderDeletedEvent

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -11,14 +11,6 @@ services:
     tags:
       - name: event.listener
         identifier: 'tm/file_list'
-        method: 'afterFileAdded'
-        event: TYPO3\CMS\Core\Resource\Event\AfterFileAddedEvent
-      - name: event.listener
-        identifier: 'tm/file_list'
-        method: 'afterFileCopied'
-        event: TYPO3\CMS\Core\Resource\Event\AfterFileCopiedEvent
-      - name: event.listener
-        identifier: 'tm/file_list'
         method: 'afterFileMoved'
         event: TYPO3\CMS\Core\Resource\Event\AfterFileMovedEvent
       - name: event.listener
@@ -31,24 +23,12 @@ services:
         event: TYPO3\CMS\Core\Resource\Event\AfterFileReplacedEvent
       - name: event.listener
         identifier: 'tm/file_list'
-        method: 'afterFileCreated'
-        event: TYPO3\CMS\Core\Resource\Event\AfterFileCreatedEvent
-      - name: event.listener
-        identifier: 'tm/file_list'
         method: 'afterFileDeleted'
         event: TYPO3\CMS\Core\Resource\Event\AfterFileDeletedEvent
       - name: event.listener
         identifier: 'tm/file_list'
         method: 'afterFileContentsSet'
         event: TYPO3\CMS\Core\Resource\Event\AfterFileContentsSetEvent
-      - name: event.listener
-        identifier: 'tm/file_list'
-        method: 'afterFolderAdded'
-        event: TYPO3\CMS\Core\Resource\Event\AfterFolderAddedEvent
-      - name: event.listener
-        identifier: 'tm/file_list'
-        method: 'afterFolderCopied'
-        event: TYPO3\CMS\Core\Resource\Event\AfterFolderCopiedEvent
       - name: event.listener
         identifier: 'tm/file_list'
         method: 'afterFolderMoved'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,21 +7,6 @@ $_EXTKEY = 'tm_cloudfront';
 // Clear cache
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['tm_cloudfront'] = 'Toumoro\TmCloudfront\Hooks\ClearCachePostProc->clearCachePostProc';
 
-$signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
-
-$signalsToRegister = [
-    'File Index Record created' => [
-        \TYPO3\CMS\Core\Resource\ResourceStorage::class, 'postFileAdd',\Toumoro\TmCloudfront\Hooks\ClearCachePostProc::class, 'fileMod'  ],
-    'File Index Record replace' => [
-        \TYPO3\CMS\Core\Resource\ResourceStorage::class, 'postFileReplace',\Toumoro\TmCloudfront\Hooks\ClearCachePostProc::class, 'fileMod'  ],
-    'File Index Record updated' => [
-        \TYPO3\CMS\Core\Resource\ResourceStorage::class, 'recordUpdated',\Toumoro\TmCloudfront\Hooks\ClearCachePostProc::class, 'fileMod' ],
-];
-foreach ($signalsToRegister as $parameters) {
-    $signalSlotDispatcher->connect($parameters[0], $parameters[1], $parameters[2], $parameters[3]);
-}
-
-
 // Add caching framework garbage collection task
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\Toumoro\TmCloudfront\Task\ClearTask::class] = array(
         'extension' => 'tm_cloudfront',


### PR DESCRIPTION
- replace signal slot with event listeners (signal doesn’t seem to work in v11) for files event ;
- clear files, bases on fileStorage distribution ids ;
- refacto, cleaning ;