### PR TITLE
Fix ClearTask incompatible avec le DenyListDeserializer de TYPO3 v13.4.31

### DIFF
--- a/Classes/Cache/CloudFrontCacheManager.php
+++ b/Classes/Cache/CloudFrontCacheManager.php
@@ -17,6 +17,7 @@
 
 namespace Toumoro\TmCloudfront\Cache;
 
+use Toumoro\TmCloudfront\Log\LoggerTrait;
 use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ProcessedFile;
@@ -35,6 +36,8 @@ use TYPO3\CMS\Core\Site\SiteFinder;
  */
 class CloudFrontCacheManager
 {
+    use LoggerTrait;
+
     protected array $queue = [];
     protected array $distributionsMapping = [];
     protected array $cloudFrontConfiguration = [];
@@ -72,10 +75,8 @@ class CloudFrontCacheManager
         $this->enqueue($resource->getIdentifier() . $wildcard, $distributionIds);
         $this->clearCache();
 
-        if (isset($GLOBALS['BE_USER'])) {
-            $errorMessage = 'fileMod distributionsIds : ' . $distributionIds . ' resource identifier : ' . $resource->getIdentifier() . ' wildcard : ' . $wildcard;
-            $GLOBALS['BE_USER']->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
-        }
+        $errorMessage = 'fileMod distributionsIds : ' . $distributionIds . ' resource identifier : ' . $resource->getIdentifier() . ' wildcard : ' . $wildcard;
+        $this->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
 
         // Reset the queue after processing for testing purposes
         $this->resetQueue();
@@ -174,7 +175,7 @@ class CloudFrontCacheManager
                 } catch (\Exception $e) {
                     // log error: could not create invalidation
                     $errorMessage = 'Could not create invalidation for distribution ID ' . $distId . ': ' . $e->getMessage();
-                    $GLOBALS['BE_USER']->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
+                    $this->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
                 }
             } else {
                 foreach ($paths as $k => $value) {
@@ -242,7 +243,7 @@ class CloudFrontCacheManager
     public function queueClearCache(int $pageId, bool $recursive = false, string|null $distributionIds = null)
     {
         $errorMessage = 'queueClearCache $pageId: ' . $pageId . ' recursive: ' . $recursive . ' distributionIds: ' . $distributionIds;
-        $GLOBALS['BE_USER']->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
+        $this->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
 
         $wildcard = '';
         if ($recursive) {
@@ -272,12 +273,12 @@ class CloudFrontCacheManager
                 } else {
                     $this->enqueue($this->buildLink($entry, array('_language' => 0)) . $wildcard, $distributionIds);
                     $errorMessage = 'queueClearCache enque lang: 0  distributionIds: ' . $distributionIds;
-                    $GLOBALS['BE_USER']->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
+                    $this->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
                     foreach ($languages as $k => $lang) {
                         if ($lang->getLanguageId() != 0) {
                             $this->enqueue($this->buildLink($entry, array('_language' => $lang->getLanguageId())) . $wildcard, $distributionIds);
                             $errorMessage = 'queueClearCache enque lang: ' . $lang->getLanguageId() . ' distributionIds: ' . $distributionIds;
-                            $GLOBALS['BE_USER']->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
+                            $this->writelog(4, 0, 0, 0, $errorMessage, ["ext" => "tm_cloudfront"]);
                         }
                     }
                 }

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -19,6 +19,7 @@ namespace Toumoro\TmCloudfront\Hooks;
 
 use Doctrine\DBAL\ParameterType;
 use Toumoro\TmCloudfront\Cache\CloudFrontCacheManager;
+use Toumoro\TmCloudfront\Log\LoggerTrait;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -29,6 +30,8 @@ use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 
 class ClearCachePostProc
 {
+    use LoggerTrait;
+
     protected array $cloudFrontConfiguration = [];
     protected array $distributionsMapping = [];
 
@@ -92,7 +95,7 @@ class ClearCachePostProc
             $domains = $this->cacheManager->getLanguagesDomains($uid_page);
             $distributionIds = $this->getDistributionsFromDomains($domains);
 
-            $GLOBALS['BE_USER']->writelog(
+            $this->writelog(
                 4,
                 0,
                 0,
@@ -147,7 +150,7 @@ class ClearCachePostProc
                 }
             }
 
-            $GLOBALS['BE_USER']->writelog(
+            $this->writelog(
                 4,
                 0,
                 0,
@@ -206,7 +209,7 @@ class ClearCachePostProc
 
         $distributionIds = $this->distributionsMapping[$domain] ?? implode(',', array_values($this->distributionsMapping));
 
-        $GLOBALS['BE_USER']->writelog(
+        $this->writelog(
             4,
             0,
             0,

--- a/Classes/Hooks/ClearCachePostProc.php
+++ b/Classes/Hooks/ClearCachePostProc.php
@@ -128,7 +128,7 @@ class ClearCachePostProc
             } else {
                 // If the record is a page, enqueue the parent page
                 if (
-                    !$tsConfig['clearCache_disable']
+                    ! ($tsConfig['clearCache_disable'] ?? false)
                     && is_numeric($parentId)
                     && !$this->isSysFolder((int)$uid_page)
                 ) {

--- a/Classes/Log/LoggerTrait.php
+++ b/Classes/Log/LoggerTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Toumoro\TmCloudfront\Log;
+
+use TYPO3\CMS\Core\Log\Logger;
+
+trait LoggerTrait
+{
+    /**
+     * Surcharge conforme à BackendUserAuthentication::writelog
+     *
+     */
+    protected function writelog(...$args) {
+        if ($this->cloudFrontConfiguration["disableLog"] ?? false) return;
+        if(!isset($GLOBALS['BE_USER'])) return;
+        $GLOBALS['BE_USER']->writelog(...$args);
+    }
+}

--- a/Classes/Task/ClearTask.php
+++ b/Classes/Task/ClearTask.php
@@ -20,14 +20,11 @@ class ClearTask extends AbstractTask
     protected array $cloudFrontConfiguration = [];
     public ?CloudFrontClient $cloudFrontClient = NULL;
 
-    public function __wakeup()
-    {
-        $this->setExtConf();
-    }
-
     public function setExtConf()
     {
-        $this->cloudFrontConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('tm_cloudfront')['cloudfront'];
+        if ($this->cloudFrontConfiguration === []) {
+            $this->cloudFrontConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('tm_cloudfront')['cloudfront'];
+        }
     }
 
     //for testing
@@ -59,6 +56,7 @@ class ClearTask extends AbstractTask
      */
     public function execute()
     {
+        $this->setExtConf();
         $distributionIds = explode(',', implode(',', $this->resolveDistributionIds()));
 
         foreach ($distributionIds as $distId) {

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ This extension clears the AWS CloudFront cache based on the speaking path of a p
              'apisecret' => 'YOUR_AWS_SECRET',
              'region' => 'us-east-1',
              'version' => 'latest',
-             'distributionIds' => '{"domain1.com":"DIST_ID_1", "domain2.com":"DIST_ID_2", "cdn.domain3.com":"DIST_ID_3", "domain4.com":"DIST_ID_4, DIST_ID_5", "domain5.com":""}'
+             'distributionIds' => '{"domain1.com":"DIST_ID_1", "domain2.com":"DIST_ID_2", "cdn.domain3.com":"DIST_ID_3", "domain4.com":"DIST_ID_4, DIST_ID_5", "domain5.com":""}',
+             'disableLog' => false
          ]
      ]
      ```
     NB: to disable cache invalidation for a specific domain, set the distribution ID to an empty string. See domain5.com in the example above.
+    NB2: set disableLog to true to disable logging of invalidation requests in the TYPO3 logs.
+
 
 2. **Storage/CDN Mapping**
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -11,4 +11,6 @@ cloudfront {
    version = latest
    # cat=basic/enable; type=string; label=Mode(live or table)
    mode = live
+   # cat=basic/enable; type=boolean; label=Disable logger
+   disableLog =
 }

--- a/ext_conf_template.typoscript
+++ b/ext_conf_template.typoscript
@@ -11,4 +11,6 @@ cloudfront {
    version = latest
    # cat=basic/enable; type=string; label=Mode(live or table)
    mode = live
+   # cat=basic/enable; type=boolean; label=Disable logger
+   disableLog =
 }


### PR DESCRIPTION
Bonjour !

En montant vers TYPO3 v13.4.31, on a découvert que la ClearTask ne peut plus être désérialisée par le Scheduler. Le nouveau DenyListDeserializer refuse toute classe qui déclare un __wakeup() user-defined — il la considère comme un gadget potentiel.

Le correctif retire le __wakeup() et charge la config extension en lazy init directement dans execute(). Le comportement reste identique, mais la tâche passe la validation du Scheduler.

De notre côté on n'utilise plus cette tâche en production, mais je me suis dit que le fix pourrait vous être utile.

N'hésite pas si vous avez des questions !